### PR TITLE
Spring 5.3.24, Spring Boot 2.7.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,7 +797,7 @@ extracted from the JDK download.
 
 ## Project dependencies
 
-* [Spring Framework](http://www.springsource.org/) (4.3.25) - `spring-test`, `spring-context` modules
+* [Spring Framework](https://spring.io/) (5.3.24) - `spring-test`, `spring-context` modules
 * [Testcontainers](https://www.testcontainers.org) (1.15.0)
 * [Cedarsoftware](https://github.com/jdereg/java-util) (1.34.0)
 * [Guava](https://github.com/google/guava) (23.0)

--- a/build.gradle
+++ b/build.gradle
@@ -215,14 +215,14 @@ project(':embedded-database-spring-test') {
 
         compile 'org.flywaydb:flyway-core:9.8.2', optional
         compile 'org.flywaydb.flyway-test-extensions:flyway-spring-test:7.0.0', optional
-        compile('org.springframework.boot:spring-boot-starter-test:2.0.9.RELEASE') {
+        compile('org.springframework.boot:spring-boot-starter-test:2.7.6') {
             exclude group: 'org.mockito'
             optionalDeps << it // https://github.com/nebula-plugins/gradle-extra-configurations-plugin/issues/44
         }
         compile 'org.liquibase:liquibase-core:3.5.5', optional
 
-        compile 'org.springframework:spring-context:5.0.20.RELEASE'
-        compile 'org.springframework:spring-test:5.0.20.RELEASE'
+        compile 'org.springframework:spring-context:5.3.24'
+        compile 'org.springframework:spring-test:5.3.24'
 
         compile 'com.google.guava:guava:23.0'
 
@@ -230,7 +230,7 @@ project(':embedded-database-spring-test') {
             exclude group: 'org.apache.logging.log4j'
         }
 
-        testCompile 'org.springframework:spring-jdbc:5.0.20.RELEASE'
+        testCompile 'org.springframework:spring-jdbc:5.3.24'
         testCompile 'ch.qos.logback:logback-classic:1.2.11'
         testCompile 'org.mockito:mockito-core:3.12.4'
         testCompile 'org.assertj:assertj-core:3.23.1'


### PR DESCRIPTION
Upgrading Spring from 5.0.20 to 5.3.24 fixes Spring4Shell:
https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-22965

Upgrading Spring Boot from 2.0.9 to 2.7.6 fixes Insecure Temporary File:
https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-27772