### PR TITLE
update guava version

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,7 +876,7 @@ extracted from the JDK download.
 * [Spring Framework](https://spring.io/) (5.3.24) - `spring-test`, `spring-context` modules
 * [Testcontainers](https://www.testcontainers.org) (1.17.6)
 * [Cedarsoftware](https://github.com/jdereg/java-util) (1.68.0)
-* [Guava](https://github.com/google/guava) (23.0)
+* [Guava](https://github.com/google/guava) (24.1.1-jre)
 
 ## License
 The project is released under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/build.gradle
+++ b/build.gradle
@@ -247,7 +247,7 @@ project(':embedded-database-spring-test') {
         compile 'org.springframework:spring-context:5.3.24'
         compile 'org.springframework:spring-test:5.3.24'
 
-        compile 'com.google.guava:guava:23.0'
+        compile 'com.google.guava:guava:24.1.1-jre'
 
         compile('com.cedarsoftware:java-util:1.68.0') {
             exclude group: 'org.apache.logging.log4j'


### PR DESCRIPTION
Update Guava to 24.1.1 to fix [CVE-2018-10237](https://github.com/google/guava/wiki/CVE-2018-10237)