### PR TITLE
#310 Add failureaccess dependency to shadow jar configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -488,6 +488,7 @@ project(':embedded-database-spring-test') {
 
         dependencies {
             include(dependency('com.google.guava:guava'))
+            include(dependency('com.google.guava:failureaccess'))
         }
 
         relocate 'com.google.common', 'io.zonky.test.db.shaded.com.google.common'


### PR DESCRIPTION
Since Guava 27, the failureaccess library is a separate dependency that needs to be included in the shadow jar alongside guava itself. This fixes the ClassNotFoundException for InternalFutureFailureAccess that was occurring in version 2.7.0.