### PR TITLE
Fix spring boot 4 compatibility with liquibase and flyway

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
             [name: '10.10.0', flyway: '10.10.0', 'flyway-test': '10.0.0',   spring: '6.1.15',   'spring-boot': '3.3.6',   'zonky-postgres': 'default'],
             [name: '10.20.1', flyway: '10.20.1', 'flyway-test': '10.0.0',   spring: '6.2.12',   'spring-boot': '3.4.11',   'zonky-postgres': 'default'],
             [name: '11.7.2',  flyway: '11.7.2',  'flyway-test': '10.0.0',   spring: '6.2.12',   'spring-boot': '3.5.7',   'zonky-postgres': 'default'],
-            [name: '11.14.1', flyway: '11.14.1', 'flyway-test': '10.0.0',   spring: '7.0.0-RC3',   'spring-boot': '4.0.0-RC2',   'zonky-postgres': 'default']
+            [name: '11.14.1', flyway: '11.14.1', 'flyway-test': '10.0.0',   spring: '7.0.3',   'spring-boot': '4.0.2',   'zonky-postgres': 'default']
     ]
 
     testSuites.find { it.name == 'liquibase' }.versions += [
@@ -118,7 +118,7 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
             [name: '4.27.0',  liquibase: '4.27.0',  spring: '6.1.15',   'spring-boot': '3.3.6'],
             [name: '4.29.2',  liquibase: '4.29.2',  spring: '6.2.12',   'spring-boot': '3.4.11'],
             [name: '4.31.1',  liquibase: '4.31.1',  spring: '6.2.12',   'spring-boot': '3.5.7'],
-            [name: '5.0.1',   liquibase: '5.0.1',   spring: '7.0.0-RC3',   'spring-boot': '4.0.0-RC2']
+            [name: '5.0.1',   liquibase: '5.0.1',   spring: '7.0.3',   'spring-boot': '4.0.2']
     ]
 }
 
@@ -132,7 +132,7 @@ subprojects {
     apply plugin: 'signing'
     apply plugin: 'com.github.johnrengelman.shadow'
 
-    sourceCompatibility = 1.8
+    sourceCompatibility = 17
 
     repositories {
         mavenCentral()
@@ -284,6 +284,14 @@ project(':embedded-database-spring-test') {
             exclude group: 'org.mockito'
         }
         optImplementation 'org.liquibase:liquibase-core:3.5.5'
+
+        // Spring Boot 4 compatibility for Liquibase/Flyway
+        optImplementation('org.springframework.boot:spring-boot-liquibase:4.0.2'){
+            exclude group: 'org.liquibase'
+        }
+        optImplementation('org.springframework.boot:spring-boot-flyway:4.0.2'){
+            exclude group: 'org.flyway'
+        }
 
         api 'org.springframework:spring-context:5.3.39'
         api 'org.springframework:spring-test:5.3.39'

--- a/embedded-database-spring-test/src/main/java/io/zonky/test/db/config/EmbeddedDatabaseAutoConfiguration.java
+++ b/embedded-database-spring-test/src/main/java/io/zonky/test/db/config/EmbeddedDatabaseAutoConfiguration.java
@@ -18,10 +18,12 @@ package io.zonky.test.db.config;
 
 import io.zonky.test.db.flyway.FlywayDatabaseExtension;
 import io.zonky.test.db.flyway.FlywayPropertiesPostProcessor;
+import io.zonky.test.db.flyway.SpringBoot4FlywayPropertiesPostProcessor;
 import io.zonky.test.db.init.EmbeddedDatabaseInitializer;
 import io.zonky.test.db.init.ScriptDatabasePreparer;
 import io.zonky.test.db.liquibase.LiquibaseDatabaseExtension;
 import io.zonky.test.db.liquibase.LiquibasePropertiesPostProcessor;
+import io.zonky.test.db.liquibase.SpringBoot4LiquibasePropertiesPostProcessor;
 import io.zonky.test.db.provider.DatabaseProvider;
 import io.zonky.test.db.provider.derby.DerbyDatabaseProvider;
 import io.zonky.test.db.provider.h2.H2DatabaseProvider;
@@ -274,6 +276,14 @@ public class EmbeddedDatabaseAutoConfiguration implements BeanClassLoaderAware {
 
     @Bean
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    @ConditionalOnClass(name = "org.springframework.boot.flyway.autoconfigure.FlywayProperties")
+    @ConditionalOnMissingBean(name = "springBoot4FlywayPropertiesPostProcessor")
+    public SpringBoot4FlywayPropertiesPostProcessor springBoot4FlywayPropertiesPostProcessor() {
+        return new SpringBoot4FlywayPropertiesPostProcessor();
+    }
+
+    @Bean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     @ConditionalOnClass(name = "liquibase.integration.spring.SpringLiquibase")
     @ConditionalOnMissingBean(name = "liquibaseDatabaseExtension")
     public LiquibaseDatabaseExtension liquibaseDatabaseExtension() {
@@ -286,6 +296,14 @@ public class EmbeddedDatabaseAutoConfiguration implements BeanClassLoaderAware {
     @ConditionalOnMissingBean(name = "liquibasePropertiesPostProcessor")
     public LiquibasePropertiesPostProcessor liquibasePropertiesPostProcessor() {
         return new LiquibasePropertiesPostProcessor();
+    }
+
+    @Bean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    @ConditionalOnClass(name = "org.springframework.boot.liquibase.autoconfigure.LiquibaseProperties")
+    @ConditionalOnMissingBean(name = "springBoot4LiquibasePropertiesPostProcessor")
+    public SpringBoot4LiquibasePropertiesPostProcessor springBoot4LiquibasePropertiesPostProcessor() {
+        return new SpringBoot4LiquibasePropertiesPostProcessor();
     }
 
     @Bean

--- a/embedded-database-spring-test/src/main/java/io/zonky/test/db/flyway/SpringBoot4FlywayPropertiesPostProcessor.java
+++ b/embedded-database-spring-test/src/main/java/io/zonky/test/db/flyway/SpringBoot4FlywayPropertiesPostProcessor.java
@@ -1,0 +1,30 @@
+package io.zonky.test.db.flyway;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.flyway.autoconfigure.FlywayProperties;
+import org.springframework.core.Ordered;
+
+public class SpringBoot4FlywayPropertiesPostProcessor implements BeanPostProcessor, Ordered {
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE - 1;
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof FlywayProperties) {
+            FlywayProperties properties = (FlywayProperties) bean;
+            properties.setUrl(null);
+            properties.setUser(null);
+            properties.setPassword(null);
+        }
+        return bean;
+    }
+}

--- a/embedded-database-spring-test/src/main/java/io/zonky/test/db/liquibase/SpringBoot4LiquibasePropertiesPostProcessor.java
+++ b/embedded-database-spring-test/src/main/java/io/zonky/test/db/liquibase/SpringBoot4LiquibasePropertiesPostProcessor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.zonky.test.db.liquibase;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.liquibase.autoconfigure.LiquibaseProperties;
+import org.springframework.core.Ordered;
+
+public class SpringBoot4LiquibasePropertiesPostProcessor implements BeanPostProcessor, Ordered {
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE - 1;
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof LiquibaseProperties) {
+            LiquibaseProperties properties = (LiquibaseProperties) bean;
+            properties.setUrl(null);
+            properties.setUser(null);
+            properties.setPassword(null);
+        }
+        return bean;
+    }
+}


### PR DESCRIPTION
Fix proposition for #319 

The goal is to have both `org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties` and `org.springframework.boot.liquibase.autoconfigure.LiquibaseProperties` classes on the classpath.

In spring boot 2 & 3, `org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties` is inside module `spring-boot-starter-autoconfigure`.

In spring boot 4, `org.springframework.boot.liquibase.autoconfigure.LiquibaseProperties` has been moved to `spring-boot-liquibase`.

If i add `spring-boot-liquibase`, I can therefore have both classes on the classpath.

However, unfortunately, spring boot 4 is [not compatible with java 8](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide#review-system-requirements).
I can't build the project with java 8, and forced to upgrade `sourceCompatibility` in `build.gradle`...